### PR TITLE
Replace usage of os with pathlib methods where available

### DIFF
--- a/wrfhydro/one_off_scripts/example_job_model_dates.py
+++ b/wrfhydro/one_off_scripts/example_job_model_dates.py
@@ -1,4 +1,4 @@
-zip()# add_job
+# add_job
 ## solve  model_start_time, model_end_time, model_restart variables.
 ### handle nones
 ## copy namelist from setup object to job

--- a/wrfhydro/one_off_scripts/example_job_model_dates.py
+++ b/wrfhydro/one_off_scripts/example_job_model_dates.py
@@ -1,4 +1,4 @@
-# add_job
+zip()# add_job
 ## solve  model_start_time, model_end_time, model_restart variables.
 ### handle nones
 ## copy namelist from setup object to job

--- a/wrfhydropy/core/dartclasses.py
+++ b/wrfhydropy/core/dartclasses.py
@@ -1,17 +1,11 @@
-import copy
-import datetime
 import f90nml
-import json
 import os
 import pathlib
 import pickle
-import re
 import shlex
 import shutil
 import subprocess
 import uuid
-import warnings
-import xarray as xr
 
 from .utilities import get_git_revision_hash
 from .ensemble import WrfHydroEnsembleRun

--- a/wrfhydropy/core/ensemble.py
+++ b/wrfhydropy/core/ensemble.py
@@ -29,7 +29,7 @@ class WrfHydroEnsembleSetup(object):
     ):
         """Instantiate a WrfHydroEnsembleSim object.
         Args:
-            members: 
+            members: A list of wrfhydropy.WrfHydroSetup objects
             ensemble_dir: Optional, 
         Returns:
             A WrfHydroEnsembleSim object.
@@ -45,6 +45,7 @@ class WrfHydroEnsembleSetup(object):
     # The "canonical" name for len
     @property
     def N(self):
+        """The "canonical" name for len"""
         return(self.__len__())
 
     # Data to store with the "member" simulations, conceptually this
@@ -95,17 +96,15 @@ class WrfHydroEnsembleSetup(object):
         else:
             self.members = [ self.members[0] for nn in range(N-1) ]
 
-
-    # The diffs_dict attribute has getter (@property) and setter methods.
-    # The get method summarizes all differences across all the attributes of the
-    #   members list attribute and (should) only report member attributes when there
-    #   is at least one difference between members.
-    # The setter method is meant as a convenient way to specify the differences in
-    #   member attributes across the ensemble.
-
-
     @property        
     def diffs_dict(self):
+        '''The diffs_dict attribute has getter (@property) and setter methods.
+        The get method summarizes all differences across all the attributes of the
+        members list attribute and (should) only report member attributes when there
+        is at least one difference between members.
+        The setter method is meant as a convenient way to specify the differences in
+        member attributes across the ensemble.
+        '''
 
         if len(self) == 1:
             print('Ensemble is of lenght 1, no differences.')

--- a/wrfhydropy/core/job_tools.py
+++ b/wrfhydropy/core/job_tools.py
@@ -17,7 +17,7 @@ import yaml
 # Where is wrfhydropy/core dir in the filesystem?
 # A method (used by  django) about specifying the root dir of the project.
 # https://stackoverflow.com/questions/25389095/python-get-path-of-root-project-structure
-core_dir = pathlib.PosixPath(os.path.dirname(os.path.abspath(__file__)))
+core_dir = pathlib.Path(__file__).absolute().parent
 DATA_PATH = pathlib.Path(pkg_resources.resource_filename('wrfhydropy', 'core/data/'))
 
 
@@ -45,8 +45,8 @@ def get_sched_name():
 
 
 def in_docker():
-    path = "/proc/" + str(os.getpid()) + "/cgroup"
-    if not os.path.isfile(path): return False
+    path = pathlib.Path("/proc/" + str(os.getpid()) + "/cgroup")
+    if not path.is_file(): return False
     with open(path) as f:
         for line in f:
             if re.match("\d+:[\w=]+:/docker(-[ce]e)?/\w+", line):

--- a/wrfhydropy/core/utilities.py
+++ b/wrfhydropy/core/utilities.py
@@ -3,7 +3,6 @@ import f90nml
 import io
 import os
 import pandas as pd
-import pathlib
 import subprocess
 import warnings
 import xarray as xr
@@ -233,7 +232,7 @@ def unlock_pickle(run_obj):
     if not is_pickle_locked(run_obj):
         raise ValueError('The pickle file, ' + run_obj.run_dir + ', is already unlocked')
     pickle_lock_file = get_pickle_lock_file(run_obj)
-    os.remove(pickle_lock_file)
+    pickle_lock_file.unlink()
     run_obj._pickle_lock_file = None
 
 

--- a/wrfhydropy/core/wrfhydroclasses.py
+++ b/wrfhydropy/core/wrfhydroclasses.py
@@ -1,7 +1,6 @@
 import copy
 import datetime
 import json
-import os
 import pathlib
 import pickle
 import re
@@ -554,7 +553,7 @@ class WrfHydroRun(object):
                        *self.setup.domain.lsm_files]
         for ff in model_files:
                 if re.match('.*/RESTART/.*',str(ff)):
-                    symlink_path = self.run_dir.joinpath(os.path.basename(ff)).absolute()
+                    symlink_path = self.run_dir.joinpath(ff.name).absolute()
                     symlink_path.symlink_to(ff)
 
         if jobs:

--- a/wrfhydropy/core/wrfhydroclasses.py
+++ b/wrfhydropy/core/wrfhydroclasses.py
@@ -554,7 +554,7 @@ class WrfHydroRun(object):
                        *self.setup.domain.lsm_files]
         for ff in model_files:
                 if re.match('.*/RESTART/.*',str(ff)):
-                    symlink_path = self.run_dir.joinpath(os.path.basename(ff))
+                    symlink_path = self.run_dir.joinpath(os.path.basename(ff)).absolute()
                     symlink_path.symlink_to(ff)
 
         if jobs:

--- a/wrfhydropy/core/wrfhydroclasses.py
+++ b/wrfhydropy/core/wrfhydroclasses.py
@@ -108,18 +108,18 @@ class WrfHydroModel(object):
 
         ## Load master namelists
         self.hydro_namelists = \
-            json.load(open(self.source_dir.joinpath('hydro_namelists.json')))
+            json.load(self.source_dir.joinpath('hydro_namelists.json').open())
 
         self.hrldas_namelists = \
-            json.load(open(self.source_dir.joinpath('hrldas_namelists.json')))
+            json.load(self.source_dir.joinpath('hrldas_namelists.json').open())
 
         ## Get code version
-        with open(self.source_dir.joinpath('.version')) as f:
+        with self.source_dir.joinpath('.version').open() as f:
             self.version = f.read()
 
         ## Load compile options
         self.model_config = model_config
-        compile_options = json.load(open(self.source_dir.joinpath('compile_options.json')))
+        compile_options = json.load(self.source_dir.joinpath('compile_options.json').open())
         self.compile_options = compile_options[self.version][self.model_config]
 
     def compile(
@@ -167,7 +167,7 @@ class WrfHydroModel(object):
         compile_options_file = self.source_dir.joinpath('compile_options.sh')
 
         # Write setEnvar file
-        with open(compile_options_file,'w') as file:
+        with compile_options_file.open(mode='w') as file:
             for option, value in self.compile_options.items():
                 file.write("export {}={}\n".format(option, value))
 
@@ -188,7 +188,7 @@ class WrfHydroModel(object):
         # this directory with another object
         self.object_id = str(uuid.uuid4())
 
-        with open(self.compile_dir.joinpath('.uid'),'w') as f:
+        with self.compile_dir.joinpath('.uid').open(mode='w') as f:
             f.write(self.object_id)
 
         if self.compile_log.returncode == 0:
@@ -218,7 +218,7 @@ class WrfHydroModel(object):
             self.wrf_hydro_exe = self.compile_dir.joinpath('wrf_hydro.exe')
 
             # Save the object out to the compile directory
-            with open(self.compile_dir.joinpath('WrfHydroModel.pkl'), 'wb') as f:
+            with self.compile_dir.joinpath('WrfHydroModel.pkl').open(mode='wb') as f:
                 pickle.dump(self, f, 2)
 
             print('Model successfully compiled into ' + str(self.compile_dir))
@@ -256,7 +256,7 @@ class WrfHydroDomain(object):
         """pathlib.Path: pathlib.Path to the namelist_patches json file."""
 
         # Load namelist patches
-        self.namelist_patches = json.load(open(self.namelist_patch_file, 'r'))
+        self.namelist_patches = json.load(self.namelist_patch_file.open(mode='r'))
         """dict: Domain-specific namelist settings."""
 
         self.model_version = model_version
@@ -393,12 +393,12 @@ class WrfHydroSetup(object):
     ):
         # create a UID for the run and save in file
         self.object_id = str(uuid.uuid4())
-        with open(dir.joinpath('.uid'), 'w') as f:
+        with dir.joinpath('.uid').open(mode='w') as f:
             f.write(self.object_id)
 
         # Save object to run directory
         # Save the object out to the compile directory
-        with open(dir.joinpath('WrfHydroSetup.pkl'), 'wb') as f:
+        with dir.joinpath('WrfHydroSetup.pkl').open(mode='wb') as f:
             pickle.dump(self, f, 2)
 
 
@@ -487,7 +487,7 @@ class WrfHydroRun(object):
 
         # Check that compile object uid matches compile directory uid
         # This is to ensure that a new model has not been compiled into that directory unknowingly
-        with open(self.setup.model.compile_dir.joinpath('.uid')) as f:
+        with self.setup.model.compile_dir.joinpath('.uid').open() as f:
             compile_uid = f.read()
 
         if self.setup.model.object_id != compile_uid:
@@ -751,18 +751,18 @@ class WrfHydroRun(object):
     def pickle(self):
         # create a UID for the run and save in file
         self.object_id = str(uuid.uuid4())
-        with open(self.run_dir.joinpath('.uid'), 'w') as f:
+        with self.run_dir.joinpath('.uid').open('w') as f:
             f.write(self.object_id)
 
         # Save object to run directory
         # Save the object out to the compile directory
-        with open(self.run_dir.joinpath('WrfHydroRun.pkl'), 'wb') as f:
+        with self.run_dir.joinpath('WrfHydroRun.pkl').open('wb') as f:
             pickle.dump(self, f, 2)
 
 
     def unpickle(self):
         # Load run object from run directory after a scheduler job
-        with open(self.run_dir.joinpath('WrfHydroRun.pkl'), 'rb') as f:
+        with self.run_dir.joinpath('WrfHydroRun.pkl').open('rb') as f:
             return(pickle.load(f))
 
 
@@ -810,7 +810,7 @@ class DomainDirectory(object):
         self.namelist_patch_file = self.domain_top_dir.joinpath(namelist_patch_file)
 
         # Load namelist patches
-        self.namelist_patches = json.load(open(self.namelist_patch_file, 'r'))
+        self.namelist_patches = json.load(self.namelist_patch_file.open(mode='r'))
 
         self.model_version = model_version
         self.domain_config = domain_config


### PR DESCRIPTION
There is a mix of methods for treament of paths between os. methods and pathlib. methods. Since all filepaths are handled using pathlib.Path, pathlib methods have been used throughout.

Additionally, pytohn open methods have been replaced by the more appropriate pathlib.Path.open() method. 

Also a start at some docstrings in new classes