### PR TITLE
Parallel xrcmp and xrnan

### DIFF
--- a/wrfhydropy/core/ioutils.py
+++ b/wrfhydropy/core/ioutils.py
@@ -622,7 +622,8 @@ def check_input_files(
 
 
 def check_file_nans(
-    dataset_or_path: Union[str, pathlib.Path, xr.Dataset]
+    dataset_or_path: Union[str, pathlib.Path, xr.Dataset],
+    n_cores: int = 1
 ) -> Union[pd.DataFrame, None]:
     """Opens the specified netcdf file and checks all data variables for NA values. NA assigned
     according to xarray __FillVal parsing. See xarray.Dataset documentation
@@ -630,7 +631,7 @@ def check_file_nans(
         dataset_or_path: The path to the netcdf dataset file, or a dataset itself
     Returns: string summary of nans if present
     """
-    return xrnan(dataset_or_path)
+    return xrnan(dataset_or_path, n_cores=n_cores)
 
 
 def sort_files_by_time(file_list: list):

--- a/wrfhydropy/core/outputdiffs.py
+++ b/wrfhydropy/core/outputdiffs.py
@@ -46,7 +46,7 @@ def compare_ncfiles(
         file_candidate = pathlib.Path(files[0])
         file_reference = pathlib.Path(files[1])
 
-        if xrcmp_n_cores > 0 and '--metadata' not in nccmp_options:
+        if xrcmp_n_cores > 1 and '--metadata' not in nccmp_options:
             cmp_func = _compare_nc_xrcmp
         else:
             cmp_func = _compare_nc_nccmp

--- a/wrfhydropy/core/outputdiffs.py
+++ b/wrfhydropy/core/outputdiffs.py
@@ -9,12 +9,15 @@ from ..util.xrcmp import xrcmp
 from .simulation import SimulationOutput
 
 
-def compare_ncfiles(candidate_files: list,
-                    reference_files: list,
-                    stats_only: bool = False,
-                    nccmp_options: list = None,
-                    exclude_vars: list = None,
-                    exclude_atts: list = None):
+def compare_ncfiles(
+    candidate_files: list,
+    reference_files: list,
+    stats_only: bool = False,
+    nccmp_options: list = None,
+    exclude_vars: list = None,
+    exclude_atts: list = None,
+    xrcmp_n_cores: int = 0
+):
     """Compare lists of netcdf restart files element-wise. Files must have common names
     Args:
         candidate_files: List of candidate netcdf file paths
@@ -43,8 +46,7 @@ def compare_ncfiles(candidate_files: list,
         file_candidate = pathlib.Path(files[0])
         file_reference = pathlib.Path(files[1])
 
-        # TODO: use XRCMP only when it supports metadata:
-        if ('--data' in nccmp_options) and ('--metadata' not in nccmp_options):
+        if xrcmp_n_cores > 0 and '--metadata' not in nccmp_options:
             cmp_func = _compare_nc_xrcmp
         else:
             cmp_func = _compare_nc_nccmp
@@ -55,7 +57,8 @@ def compare_ncfiles(candidate_files: list,
             stats_only=stats_only,
             nccmp_options=nccmp_options,
             exclude_vars=exclude_vars,
-            exclude_atts=exclude_atts
+            exclude_atts=exclude_atts,
+            n_cores=xrcmp_n_cores
         )
         output_list.append(nccmp_out)
     return output_list
@@ -68,7 +71,8 @@ class OutputDataDiffs(object):
         reference_output: SimulationOutput,
         nccmp_options: list = None,
         exclude_vars: list = None,
-        exclude_atts: list = None
+        exclude_atts: list = None,
+        xrcmp_n_cores: int = 0
     ):
         """Calculate Diffs between SimulationOutput objects from two WrfHydroSim objects
         Args:
@@ -149,7 +153,8 @@ class OutputDataDiffs(object):
                         stats_only=True,
                         nccmp_options=nccmp_options,
                         exclude_vars=exclude_vars,
-                        exclude_atts=exclude_atts
+                        exclude_atts=exclude_atts,
+                        xrcmp_n_cores=xrcmp_n_cores
                     )
                 )
                 diff_counts = sum(1 for _ in filter(None.__ne__, getattr(self, att)))
@@ -157,13 +162,16 @@ class OutputDataDiffs(object):
 
 
 class OutputMetaDataDiffs(object):
-    def __init__(self,
-                 candidate_output: SimulationOutput,
-                 reference_output: SimulationOutput,
-                 stats_only=False,
-                 nccmp_options: list = None,
-                 exclude_vars: list = None,
-                 exclude_atts: list = None):
+    def __init__(
+        self,
+        candidate_output: SimulationOutput,
+        reference_output: SimulationOutput,
+        stats_only=False,
+        nccmp_options: list = None,
+        exclude_vars: list = None,
+        exclude_atts: list = None,
+        xrcmp_n_cores: int = 0
+    ):
         """Calculate Diffs between SimulationOutput objects from two WrfHydroSim objects
         Args:
             candidate_output: The candidate SimulationOutput object
@@ -238,20 +246,24 @@ class OutputMetaDataDiffs(object):
                         reference_files=valid_files[1],
                         nccmp_options=nccmp_options,
                         exclude_vars=exclude_vars,
-                        exclude_atts=exclude_atts
+                        exclude_atts=exclude_atts,
+                        xrcmp_n_cores=xrcmp_n_cores
                     )
                 )
                 diff_counts = sum(1 for _ in filter(None.__ne__, getattr(self, att)))
                 self.diff_counts.update({att: diff_counts})
 
 
-def _compare_nc_xrcmp(candidate_nc: str,
-                      reference_nc: str,
-                      stats_only: bool = False,
-                      nccmp_options: list = None,
-                      exclude_vars: list = None,
-                      exclude_atts: list = None,
-                      log_file_path: str = "xrcmp.log"):
+def _compare_nc_xrcmp(
+    candidate_nc: str,
+    reference_nc: str,
+    stats_only: bool = False,
+    nccmp_options: list = None,
+    exclude_vars: list = None,
+    exclude_atts: list = None,
+    n_cores=1,
+    log_file_path: str = "xrcmp.log"
+):
 
     # Try and set files to strings
     candidate_nc = str(candidate_nc)
@@ -264,7 +276,8 @@ def _compare_nc_xrcmp(candidate_nc: str,
             can_file=candidate_nc,
             ref_file=reference_nc,
             log_file=str(log_file_path),
-            exclude_vars=exclude_vars
+            exclude_vars=exclude_vars,
+            n_cores=n_cores
         )
 
     if ret != 0:
@@ -285,12 +298,15 @@ def _compare_nc_xrcmp(candidate_nc: str,
         return None
 
 
-def _compare_nc_nccmp(candidate_nc: str,
-                      reference_nc: str,
-                      stats_only: bool = False,
-                      nccmp_options: list = None,
-                      exclude_vars: list = None,
-                      exclude_atts: list = None):
+def _compare_nc_nccmp(
+    candidate_nc: str,
+    reference_nc: str,
+    stats_only: bool = False,
+    nccmp_options: list = None,
+    exclude_vars: list = None,
+    exclude_atts: list = None,
+    n_cores: int = 0
+):
 
     """Private method to compare two netcdf files using nccmp.
     This is wrapped by compare ncfiles to applying to a list of one or more files

--- a/wrfhydropy/core/simulation.py
+++ b/wrfhydropy/core/simulation.py
@@ -469,7 +469,7 @@ class SimulationOutput(object):
         else:
             self.restart_nudging = None
 
-    def check_output_nans(self):
+    def check_output_nans(self, n_cores: int = 1):
         """Check all outputs for NA values"""
 
         # Get all the public attributes, which are the only atts of interest
@@ -484,7 +484,7 @@ class SimulationOutput(object):
             att_obj = getattr(self, att)
             if type(att_obj) is list or type(att_obj) is WrfHydroTs:
                 file = att_obj[-1]
-                na_check_result = check_file_nans(file)
+                na_check_result = check_file_nans(file, n_cores=n_cores)
                 if na_check_result is not None:
                     na_check_result['file'] = str(file)
                     df_list.append(na_check_result)

--- a/wrfhydropy/tests/test_ioutils.py
+++ b/wrfhydropy/tests/test_ioutils.py
@@ -98,7 +98,7 @@ def test_wrfhydrots(ds_timeseries):
     ts_obj_open = ts_obj.open()
 
     assert type(ts_obj_open) == xr.core.dataset.Dataset
-    assert type(ts_obj.check_nans()) == pd.DataFrame
+    assert type(ts_obj.check_nans()) == dict
 
 
 def test_wrfhydrostatic(ds_timeseries):
@@ -108,7 +108,7 @@ def test_wrfhydrostatic(ds_timeseries):
     static_obj_open = static_obj.open()
 
     assert type(static_obj_open) == xr.core.dataset.Dataset
-    assert type(static_obj.check_nans()) == pd.DataFrame
+    assert type(static_obj.check_nans()) == dict
 
 
 def test_check_input_files(domain_dir):

--- a/wrfhydropy/tests/test_utils.py
+++ b/wrfhydropy/tests/test_utils.py
@@ -121,8 +121,8 @@ def test_xrnan_none(filename, expected, tmpdir):
     ['filename', 'expected'],
     [
         ('fill_value.nc', 'None'),
-        ('nan_fill.nc', '     some_var\ndim          \n0         NaN\n1         NaN'),
-        ('nan_value.nc', '     some_var\ndim          \n0         NaN\n1         NaN'),
+        ('nan_fill.nc', "{'vars': ['some_var']}"),
+        ('nan_value.nc', "{'vars': ['some_var']}"),
         ('value_value.nc', 'None'),
     ],
     ids=[

--- a/wrfhydropy/util/xrcmp.py
+++ b/wrfhydropy/util/xrcmp.py
@@ -56,7 +56,6 @@ def calc_stats(arg_tuple):
 
     # Check for variables in reference and not in candidate?
     # Check for variables in candidate and not in reference?
-    print(key)
 
     if can_ds[key].equals(ref_ds[key]):
         return None
@@ -154,8 +153,8 @@ def xrcmp(
     can_vars = set([kk for kk in can_ds.variables.keys()])
     ref_vars = set([kk for kk in ref_ds.variables.keys()])
     have_same_variables = can_vars.difference(ref_vars) == set([])
-    can_ds.close()
-    ref_ds.close()
+    can_ds.close()  # These are likely critical to the success
+    ref_ds.close()  # of multiprocessing
 
     # TODO: Check that the meta data matches
 

--- a/wrfhydropy/util/xrnan.py
+++ b/wrfhydropy/util/xrnan.py
@@ -22,7 +22,7 @@ def xrnan(
     dataset_or_path: Union[str, pathlib.Path, xr.Dataset],
     log_file: str = None,
     exclude_vars: list = [],
-    chunks = None,
+    chunks=None,
     n_cores: int = 1
 ) -> int:
     # Set filepath to strings

--- a/wrfhydropy/util/xrnan.py
+++ b/wrfhydropy/util/xrnan.py
@@ -1,25 +1,61 @@
+from multiprocessing import Pool
 import pathlib
 import sys
 from typing import Union
 import xarray as xr
 
 
+def check_nans(arg_dict):
+    var_name = arg_dict['var_name']
+    if 'path' in arg_dict.keys():
+        path = arg_dict['path']
+        ds = xr.open_dataset(path, mask_and_scale=False)
+    else:
+        ds = arg_dict['ds']
+    if ds[var_name].isnull().any().values:
+        return var_name
+    else:
+        return None
+
+
 def xrnan(
     dataset_or_path: Union[str, pathlib.Path, xr.Dataset],
     log_file: str = None,
-    exclude_vars: list = []
+    exclude_vars: list = [],
+    chunks = None,
+    n_cores: int = 1
 ) -> int:
     # Set filepath to strings
     if not isinstance(dataset_or_path, xr.Dataset):
-        ds = xr.open_dataset(str(dataset_or_path), mask_and_scale=False)
+        ds = xr.open_dataset(str(dataset_or_path), mask_and_scale=False, chunks=chunks)
     else:
         ds = dataset_or_path
 
-    if ds.isnull().any().to_array().data.any():
-        print(str(dataset_or_path), "has NaNs")
-        return ds.where(ds.isnull()).to_dataframe()
+    # Looping on variables is much faster for small applications and parallelizable
+    # for larger ones.
+    if n_cores < 2 or isinstance(dataset_or_path, xr.Dataset):
+        nan_vars = []
+        for var_name in ds.variables:
+            nan_vars.append(check_nans({'var_name': var_name, 'ds': ds}))
+        ds.close()
     else:
+        # The following ds.close() is CRITICAL to the correct results being returned by
+        # multiprocessing
+        ds.close()
+        the_args = [{'var_name': var_name, 'path': dataset_or_path}
+                    for var_name in ds.variables]
+        with Pool(n_cores) as pool:
+            nan_vars = pool.map(check_nans, the_args)
+
+    nan_vars_2 = [var for var in nan_vars if var is not None]
+
+    if len(nan_vars_2) == 0:
         return None
+    else:
+        for var in nan_vars_2:
+            print(str(dataset_or_path), ': variable "' + var + ''
+                  '' + '" contains NaNs')
+        return {'vars': nan_vars_2}
 
 
 def parse_arguments():


### PR DESCRIPTION
This supports https://github.com/NCAR/wrf_hydro_nwm_public/pull/362

1. Made xrnan variable-wise and parallelizable. (Noted that crazy behavoir happens if you pass a dataset to multiprocessing or if you even leave a dataset open which a multiprocess also opens). 

2. nccmp always for metadata diffs

3. allow core counts (>1) requested to trigger xrcmp instead of nccmp

4. I seem to have lost some minor logging changes I made to xrcmp. 