### PR TITLE
Team fcst

### DIFF
--- a/wrfhydropy/core/cycle.py
+++ b/wrfhydropy/core/cycle.py
@@ -19,7 +19,7 @@ from .job import Job
 from .schedulers import Scheduler
 from .simulation import Simulation
 from .ensemble import EnsembleSimulation
-
+from .teams import parallel_teams_run
 
 def integer_coercable(val):
     try:
@@ -182,122 +182,6 @@ def parallel_run_casts(arg_dict):
     return exit_status
 
 
-def parallel_teams_run(arg_dict):
-    """Parallelizable function for teams to run an EnsembleSimuation.
-
-    This function is called (in parallel) once for each team. (First level of parallelism
-    is from python multiprocessing.
-    This function (a team) sequentially runs (loops over) the ensemble members for which
-    the team is responsible.
-    This function (a team) makes a system call using MPI. (The second level of parallelism).
-
-    # TODO: extract this to be used by both cycles and ensembles.
-
-    Arguments:
-        arg_dict:
-            arg_dict == {
-               'obj_name'   : string, either "member" or "cast" (or some other object),
-                              matches the object name used in the team_dict below (first
-                              argument)
-               'compose_dir': <pathlib.Path absolute path to the cycle top level/compse,
-                               dir where the individual cycle dirs are found>,
-               'team_dict'  : <dict: the information needed for the team, see below>
-            }
-            where
-            team_dict == {
-                'casts'    : <list: length n_team, groups of cast run_dirs>
-                'nodes'    : <list: the nodes previously parsed from something like
-                              $PBS_NODEFILE>,
-                'entry_cmd': <string: the entry cmd to be run>,
-                'exe_cmd'  : <string: the MPI-specific model invokation command>,
-                'exit_cmd' : <string: exit cmd to be run>,
-                'env'      : <dict: containging the environment in which to run the
-                              cmds, may be None or 'None'>
-            }
-
-            The 'exe_cmd' is a form of invocation for the distribution of MPI to be used. For
-            openmpi, for example for OpenMPI, this is
-                exe_cmd: 'mpirun --host {hostnames} -np {nproc} {cmd}'
-            The variables in brackets are expanded by internal variables. The 'exe_cmd'
-            command substitutes the wrfhydropy of 'wrf_hydro.exe' convention for {cmd}.
-            The {nproc} argument is the length of the list passed in the nodes argument,
-            and the {hostnames} are the comma separated arguments in that list.
-
-            The "entry_cmd" and "exit_cmd"
-              1) can be semicolon-separated commands
-              2) where these are run depends on MPI. OpenMPI, for example, handles these
-                 on the same processor set as the model runs.
-
-    Notes:
-        Currently this is working/tested with openmpi.
-        MPT requires MPI_SHEPERD env variable and it's performance is not satisfactory so far.
-    """
-
-    obj_name = arg_dict['obj_name']
-    compose_dir = arg_dict['compose_dir']
-    team_dict = arg_dict['team_dict']
-
-    exit_statuses = {}
-    for obj in team_dict[obj_name]:
-        if type(obj) is str:
-            os.chdir(str(pathlib.Path(compose_dir) / obj))
-        else:
-            os.chdir(str(pathlib.Path(compose_dir) / obj.run_dir))
-
-        obj_pkl_file = "WrfHydroSim.pkl"
-        obj_pkl = pickle.load(open(obj_pkl_file, "rb"))
-        job = obj_pkl.jobs[0]
-
-        if job._entry_cmd is not None:
-            entry_cmds = job._entry_cmd.split(';')
-            new_entry_cmd = []
-            for cmd in entry_cmds:
-                if 'mpirun' not in cmd:
-                    new_entry_cmd.append(
-                        team_dict['exe_cmd'].format(
-                            **{
-                                'cmd': cmd,
-                                'hostname': team_dict['nodes'][0],  # only use one task
-                                'nproc': 1
-                            }
-                        )
-                    )
-                else:
-                    new_entry_cmd.append(cmd)
-            job._entry_cmd = '; '.join(new_entry_cmd)
-
-        if job._exit_cmd is not None:
-            exit_cmds = job._exit_cmd.split(';')
-            new_exit_cmd = []
-            for cmd in exit_cmds:
-                if 'mpirun' not in cmd:
-                    new_exit_cmd.append(
-                        team_dict['exe_cmd'].format(
-                            **{
-                                'cmd': cmd,
-                                'hostname': team_dict['nodes'][0],  # only use one task
-                                'nproc': 1
-                            }
-                        )
-                    )
-                else:
-                    new_exit_cmd.append(cmd)
-            job._exit_cmd = '; '.join(new_exit_cmd)
-
-        job._exe_cmd = team_dict['exe_cmd'].format(
-            **{
-                'cmd': './wrf_hydro.exe',
-                'hostname': ','.join(team_dict['nodes']),
-                'nproc': len(team_dict['nodes'])
-            }
-        )
-
-        obj_pkl.pickle(obj_pkl_file)
-        obj_pkl.run(env=team_dict['env'])
-
-        exit_statuses.update({obj: obj_pkl.jobs[0].exit_status})
-
-    return exit_statuses
 
 
 class CycleSimulation(object):

--- a/wrfhydropy/core/cycle.py
+++ b/wrfhydropy/core/cycle.py
@@ -182,8 +182,6 @@ def parallel_run_casts(arg_dict):
     return exit_status
 
 
-
-
 class CycleSimulation(object):
     """Class for a WRF-Hydro CycleSimulation object. The Cycle Simulation object is used to
     orchestrate a set of 'N' WRF-Hydro simulations, referred to as 'casts', which only differ

--- a/wrfhydropy/core/ensemble.py
+++ b/wrfhydropy/core/ensemble.py
@@ -19,6 +19,7 @@ from .ensemble_tools import DeepDiffEq, dictify, get_sub_objs, mute
 from .job import Job
 from .schedulers import Scheduler
 from .simulation import Simulation
+from .teams import parallel_teams_run
 
 
 def parallel_compose_addjobs(arg_dict):
@@ -56,118 +57,6 @@ def parallel_run(arg_dict):
 
     mem_pkl.run()
     return mem_pkl.jobs[0].exit_status
-
-
-def parallel_teams_run(arg_dict):
-    """Parallelizable function for teams to run an EnsembleSimuation.
-
-    This function is called (in parallel) once for each team. (First level of parallelism
-    is from python multiprocessing.
-    This function (a team) sequentially runs (loops over) the ensemble members for which
-    the team is responsible.
-    This function (a team) makes a system call using MPI. (The second level of parallelism).
-
-    Arguments:
-        arg_dict:
-            arg_dict == {
-               'ens_dir'  : <pathlib.Path absolute path to the ensemble run dir path,
-                             where the member dirs are found>,
-               'team_dict': <dict: the information needed for the team, see below>
-            }
-            where
-            team_dict == {
-                'members'  : <list: length n_team, groups of member run_dirs>
-                'nodes'    : <list: the nodes previously parsed from something like
-                              $PBS_NODEFILE>,
-                'entry_cmd': <string: the entry cmd to be run>,
-                'exe_cmd'  : <string: the MPI-specific model invokation command>,
-                'exit_cmd' : <string: exit cmd to be run>,
-                'env'      : <dict: containging the environment in which to run the
-                              cmds, may be None or 'None'>
-            }
-
-            The 'exe_cmd' is a form of invocation for the distribution of MPI to be used. For
-            openmpi, for example for OpenMPI, this is
-                exe_cmd: 'mpirun --host {hostnames} -np {nproc} {cmd}'
-            The variables in brackets are expanded by internal variables. The 'exe_cmd'
-            command substitutes the wrfhydropy of 'wrf_hydro.exe' convention for {cmd}.
-            The {nproc} argument is the length of the list passed in the nodes argument,
-            and the {hostnames} are the comma separated arguments in that list.
-
-            The "entry_cmd" and "exit_cmd"
-              1) can be semicolon-separated commands
-              2) where these are run depends on MPI. OpenMPI, for example, handles these
-                 on the same processor set as the model runs.
-
-    Notes:
-        Currently this is working/tested with openmpi.
-        MPT requires MPI_SHEPERD env variable and it's performance is not satisfactory so far.
-    """
-
-    ens_dir = arg_dict['ens_dir']
-    team_dict = arg_dict['team_dict']
-
-    exit_statuses = {}
-    for member in team_dict['members']:
-        if type(member) is str:
-            os.chdir(str(pathlib.Path(ens_dir) / member))
-        else:
-            os.chdir(str(pathlib.Path(ens_dir) / member.run_dir))
-
-        mem_pkl_file = "WrfHydroSim.pkl"
-        mem_pkl = pickle.load(open(mem_pkl_file, "rb"))
-        job = mem_pkl.jobs[0]
-
-        if job._entry_cmd is not None:
-            entry_cmds = job._entry_cmd.split(';')
-            new_entry_cmd = []
-            for cmd in entry_cmds:
-                if 'mpirun' not in cmd:
-                    new_entry_cmd.append(
-                        team_dict['exe_cmd'].format(
-                            **{
-                                'cmd': cmd,
-                                'hostname': team_dict['nodes'][0],  # only use one task
-                                'nproc': 1
-                            }
-                        )
-                    )
-                else:
-                    new_entry_cmd.append(cmd)
-            job._entry_cmd = '; '.join(new_entry_cmd)
-
-        if job._exit_cmd is not None:
-            exit_cmds = job._exit_cmd.split(';')
-            new_exit_cmd = []
-            for cmd in exit_cmds:
-                if 'mpirun' not in cmd:
-                    new_exit_cmd.append(
-                        team_dict['exe_cmd'].format(
-                            **{
-                                'cmd': cmd,
-                                'hostname': team_dict['nodes'][0],  # only use one task
-                                'nproc': 1
-                            }
-                        )
-                    )
-                else:
-                    new_exit_cmd.append(cmd)
-            job._exit_cmd = '; '.join(new_exit_cmd)
-
-        job._exe_cmd = team_dict['exe_cmd'].format(
-            **{
-                'cmd': './wrf_hydro.exe',
-                'hostname': ','.join(team_dict['nodes']),
-                'nproc': len(team_dict['nodes'])
-            }
-        )
-
-        mem_pkl.pickle(mem_pkl_file)
-        mem_pkl.run(env=team_dict['env'])
-
-        exit_statuses.update({member: mem_pkl.jobs[0].exit_status})
-
-    return exit_statuses
 
 
 # Classes for constructing and running a wrf_hydro simulation
@@ -574,7 +463,6 @@ class EnsembleSimulation(object):
         self.pickle(path)
 
         if isinstance(teams_dict, dict):
-
             # Add the env to all the teams
             for key, value in teams_dict.items():
                 value.update(env=env)
@@ -583,16 +471,24 @@ class EnsembleSimulation(object):
                 exit_codes = pool.map(
                     parallel_teams_run,
                     (
-                        {'team_dict': team_dict, 'ens_dir': ens_dir, 'env': env}
+                        {'obj_name': 'members',
+                        'team_dict': team_dict,
+                         'compose_dir': ens_dir,
+                         'env': env}
                         for (key, team_dict) in teams_dict.items()
                     )
                 )
 
-            # # Keep around for serial testing/debugging
+            # Keep around for serial testing/debugging
             # exit_codes = [
-            #     parallel_teams_run({'team_dict': team_dict, 'ens_dir': ens_dir, 'env': env})
+            #     parallel_teams_run(
+            #         {'obj_name': 'members',
+            #          'team_dict': team_dict,
+            #          'compose_dir': ens_dir,
+            #          'env': env})
             #     for (key, team_dict) in teams_dict.items()
             # ]
+
             exit_code = int(not all([list(ee.values())[0] == 0 for ee in exit_codes]))
 
         elif n_concurrent > 1:

--- a/wrfhydropy/core/ensemble.py
+++ b/wrfhydropy/core/ensemble.py
@@ -533,6 +533,7 @@ class EnsembleSimulation(object):
                         'entry_cmd': 'pwd',
                         'exe_cmd'  : './wrf_hydro.exe {hostnames} {nproc}',
                         'exit_cmd' : './bogus_cmd',
+                        'env'      : {environment dict}
                     },
                     '1': {
                         'members'  : ['member_001', 'member_003'],
@@ -540,6 +541,7 @@ class EnsembleSimulation(object):
                         'entry_cmd': 'pwd',
                         'exe_cmd'  : './wrf_hydro.exe {hostnames} {nproc}',
                         'exit_cmd' : './bogus_cmd',
+                        'env'      : {environment dict}
                     }
                 }
                 The keys are the numbers of the teams, starting with zero.
@@ -591,8 +593,6 @@ class EnsembleSimulation(object):
             #     parallel_teams_run({'team_dict': team_dict, 'ens_dir': ens_dir, 'env': env})
             #     for (key, team_dict) in teams_dict.items()
             # ]
-
-            os.chdir(ens_dir)
             exit_code = int(not all([list(ee.values())[0] == 0 for ee in exit_codes]))
 
         elif n_concurrent > 1:
@@ -602,8 +602,6 @@ class EnsembleSimulation(object):
                     parallel_run,
                     ({'member': mm, 'ens_dir': ens_dir} for mm in self.members)
                 )
-
-            os.chdir(ens_dir)
             exit_code = int(not all([ee == 0 for ee in exit_codes]))
 
         else:
@@ -612,10 +610,9 @@ class EnsembleSimulation(object):
             exit_codes = [
                 parallel_run({'member': mm, 'ens_dir': ens_dir}) for mm in self.members
             ]
-
-            os.chdir(ens_dir)
             exit_code = int(not all([ee == 0 for ee in exit_codes]))
 
+        os.chdir(ens_dir)
         return exit_code
 
     def pickle(self, path: str):

--- a/wrfhydropy/core/teams.py
+++ b/wrfhydropy/core/teams.py
@@ -4,6 +4,7 @@ import operator
 import os
 import pathlib
 import pickle
+from pprint import pprint
 import wrfhydropy
 
 
@@ -309,5 +310,9 @@ def assign_teams(
         print('    ' + str(n_runs) + ' total ' + object_name)
         print('    ' + str(n_teams) + ' concurrent teams using')
         print('    ' + str(teams_exe_cmd_nproc) + ' processors each.')
+
+        print('\nTeams dict:')
+        pprint(teams_dict)
+        print('\n')
 
         return teams_dict

--- a/wrfhydropy/core/teams.py
+++ b/wrfhydropy/core/teams.py
@@ -165,12 +165,12 @@ def assign_teams(
         object_list = obj.members
         object_name = 'members'
 
-    if 'pbs' in teams_node_file.keys():
-        pbs_node_file = teams_node_file['pbs']
+    if isinstance(teams_node_file, dict):
+        if 'pbs' in teams_node_file.keys():
+            pbs_node_file = teams_node_file['pbs']
     else:
-        pbs_node_file = os.environ.get('PBS_NODE_FILE')
-
-    # Merge other schduler files here.
+        pbs_node_file = os.environ.get('PBS_NODEFILE')
+        # Merge other schduler files here.
 
     n_runs = len(object_list)
 
@@ -204,6 +204,7 @@ def assign_teams(
         # Homogonization step here to avoid communication across nodes...
         # Sorting necessary for testing.
         unique_nodes = sorted([node.split('.')[0] for node in list(set(pbs_nodes))])
+        print("\n*** Team " + object_name + ' ***')
         print("Running on nodes: " + ', '.join(unique_nodes))
         del pbs_nodes
         pbs_nodes = []
@@ -216,7 +217,7 @@ def assign_teams(
         node_team_seq.sort(key = operator.itemgetter(1))
         team_groups = itertools.groupby(node_team_seq, operator.itemgetter(1))
         team_nodes = [[item[0] for item in data] for (key, data) in team_groups]
-        
+
         # Get the entry and exit commands from the job on the first cast/member
         # Foolery for in/out of memory
         if isinstance(object_list[0], str):
@@ -244,10 +245,11 @@ def assign_teams(
 
         print('\nPBS_NODE_FILE present: ')
         print('    ' + str(len(unique_nodes)) + ' nodes with')
-        print('    ' + str(n_total_processors) + ' processors requested.')
+        print('    ' + str(n_total_processors) + ' TOTAL processors requested.')
 
-        print('\nTeams parallelization over:')
-        print('    ' + str(n_teams) + ' concurrent teams each using')
-        print('    ' + str(teams_exe_cmd_nproc) + ' processors.')    
+        print('\nTeams parallelization:')
+        print('    ' + str(n_runs) + ' total ' + object_name)
+        print('    ' + str(n_teams) + ' concurrent teams using')
+        print('    ' + str(teams_exe_cmd_nproc) + ' processors each.')
 
         return teams_dict

--- a/wrfhydropy/core/teams.py
+++ b/wrfhydropy/core/teams.py
@@ -1,0 +1,121 @@
+import pathlib
+import os
+import pickle
+
+
+def parallel_teams_run(arg_dict):
+    """Parallelizable function for teams to run an EnsembleSimuation.
+
+    This function is called (in parallel) once for each team. (First level of parallelism
+    is from python multiprocessing.
+    This function (a team) sequentially runs (loops over) the ensemble members for which
+    the team is responsible.
+    This function (a team) makes a system call using MPI. (The second level of parallelism).
+
+    # TODO: extract this to be used by both cycles and ensembles.
+
+    Arguments:
+        arg_dict:
+            arg_dict == {
+               'obj_name'   : string, either "member" or "cast" (or some other object),
+                              matches the object name used in the team_dict below (first
+                              argument)
+               'compose_dir': <pathlib.Path absolute path to the cycle top level/compse,
+                               dir where the individual cycle dirs are found>,
+               'team_dict'  : <dict: the information needed for the team, see below>
+            }
+            where
+            team_dict == {
+                'casts'    : <list: length n_team, groups of cast run_dirs>
+                'nodes'    : <list: the nodes previously parsed from something like
+                              $PBS_NODEFILE>,
+                'entry_cmd': <string: the entry cmd to be run>,
+                'exe_cmd'  : <string: the MPI-specific model invokation command>,
+                'exit_cmd' : <string: exit cmd to be run>,
+                'env'      : <dict: containging the environment in which to run the
+                              cmds, may be None or 'None'>
+            }
+
+            The 'exe_cmd' is a form of invocation for the distribution of MPI to be used. For
+            openmpi, for example for OpenMPI, this is
+                exe_cmd: 'mpirun --host {hostnames} -np {nproc} {cmd}'
+            The variables in brackets are expanded by internal variables. The 'exe_cmd'
+            command substitutes the wrfhydropy of 'wrf_hydro.exe' convention for {cmd}.
+            The {nproc} argument is the length of the list passed in the nodes argument,
+            and the {hostnames} are the comma separated arguments in that list.
+
+            The "entry_cmd" and "exit_cmd"
+              1) can be semicolon-separated commands
+              2) where these are run depends on MPI. OpenMPI, for example, handles these
+                 on the same processor set as the model runs.
+
+    Notes:
+        Currently this is working/tested with openmpi.
+        MPT requires MPI_SHEPERD env variable and it's performance is not satisfactory so far.
+    """
+
+    obj_name = arg_dict['obj_name']
+    compose_dir = arg_dict['compose_dir']
+    team_dict = arg_dict['team_dict']
+
+    exit_statuses = {}
+    for obj in team_dict[obj_name]:
+        if type(obj) is str:
+            os.chdir(str(pathlib.Path(compose_dir) / obj))
+        else:
+            os.chdir(str(pathlib.Path(compose_dir) / obj.run_dir))
+
+        obj_pkl_file = "WrfHydroSim.pkl"
+        obj_pkl = pickle.load(open(obj_pkl_file, "rb"))
+        job = obj_pkl.jobs[0]
+
+        if job._entry_cmd is not None:
+            entry_cmds = job._entry_cmd.split(';')
+            new_entry_cmd = []
+            for cmd in entry_cmds:
+                if 'mpirun' not in cmd:
+                    new_entry_cmd.append(
+                        team_dict['exe_cmd'].format(
+                            **{
+                                'cmd': cmd,
+                                'hostname': team_dict['nodes'][0],  # only use one task
+                                'nproc': 1
+                            }
+                        )
+                    )
+                else:
+                    new_entry_cmd.append(cmd)
+            job._entry_cmd = '; '.join(new_entry_cmd)
+
+        if job._exit_cmd is not None:
+            exit_cmds = job._exit_cmd.split(';')
+            new_exit_cmd = []
+            for cmd in exit_cmds:
+                if 'mpirun' not in cmd:
+                    new_exit_cmd.append(
+                        team_dict['exe_cmd'].format(
+                            **{
+                                'cmd': cmd,
+                                'hostname': team_dict['nodes'][0],  # only use one task
+                                'nproc': 1
+                            }
+                        )
+                    )
+                else:
+                    new_exit_cmd.append(cmd)
+            job._exit_cmd = '; '.join(new_exit_cmd)
+
+        job._exe_cmd = team_dict['exe_cmd'].format(
+            **{
+                'cmd': './wrf_hydro.exe',
+                'hostname': ','.join(team_dict['nodes']),
+                'nproc': len(team_dict['nodes'])
+            }
+        )
+
+        obj_pkl.pickle(obj_pkl_file)
+        obj_pkl.run(env=team_dict['env'])
+
+        exit_statuses.update({obj: obj_pkl.jobs[0].exit_status})
+
+    return exit_statuses

--- a/wrfhydropy/core/teams.py
+++ b/wrfhydropy/core/teams.py
@@ -1,7 +1,10 @@
-import pathlib
+import itertools
+import math
+import operator
 import os
+import pathlib
 import pickle
-
+import wrfhydropy
 
 def parallel_teams_run(arg_dict):
     """Parallelizable function for teams to run an EnsembleSimuation.
@@ -28,7 +31,7 @@ def parallel_teams_run(arg_dict):
             team_dict == {
                 'casts'    : <list: length n_team, groups of cast run_dirs>
                 'nodes'    : <list: the nodes previously parsed from something like
-                              $PBS_NODEFILE>,
+                              $PBS_NODE_FILE>,
                 'entry_cmd': <string: the entry cmd to be run>,
                 'exe_cmd'  : <string: the MPI-specific model invokation command>,
                 'exit_cmd' : <string: exit cmd to be run>,
@@ -65,9 +68,9 @@ def parallel_teams_run(arg_dict):
         else:
             os.chdir(str(pathlib.Path(compose_dir) / obj.run_dir))
 
-        obj_pkl_file = "WrfHydroSim.pkl"
-        obj_pkl = pickle.load(open(obj_pkl_file, "rb"))
-        job = obj_pkl.jobs[0]
+        object_pkl_file = "WrfHydroSim.pkl"
+        object_pkl = pickle.load(open(object_pkl_file, "rb"))
+        job = object_pkl.jobs[0]
 
         if job._entry_cmd is not None:
             entry_cmds = job._entry_cmd.split(';')
@@ -75,6 +78,7 @@ def parallel_teams_run(arg_dict):
             for cmd in entry_cmds:
                 if 'mpirun' not in cmd:
                     new_entry_cmd.append(
+                        # Switch out the ./wrf_hydro.exe cmd with each command.
                         team_dict['exe_cmd'].format(
                             **{
                                 'cmd': cmd,
@@ -93,6 +97,7 @@ def parallel_teams_run(arg_dict):
             for cmd in exit_cmds:
                 if 'mpirun' not in cmd:
                     new_exit_cmd.append(
+                        # Switch out the ./wrf_hydro.exe cmd with each command.
                         team_dict['exe_cmd'].format(
                             **{
                                 'cmd': cmd,
@@ -113,9 +118,112 @@ def parallel_teams_run(arg_dict):
             }
         )
 
-        obj_pkl.pickle(obj_pkl_file)
-        obj_pkl.run(env=team_dict['env'])
+        object_pkl.pickle(object_pkl_file)
+        object_pkl.run(env=team_dict['env'])
 
-        exit_statuses.update({obj: obj_pkl.jobs[0].exit_status})
+        exit_statuses.update({obj: object_pkl.jobs[0].exit_status})
 
     return exit_statuses
+
+
+def assign_teams(
+    obj,
+    teams_exe_cmd: str,
+    teams_exe_cmd_nproc: int,
+    teams_node_file: dict = None,
+    env: dict = None    
+) -> dict:
+
+    if 'casts' in dir(obj): 
+        object_list = obj.casts
+        object_name = 'casts'
+    elif 'members' in dir(obj):
+        object_list = obj.members
+        object_name = 'members'
+
+    if 'pbs' in teams_node_file.keys():
+        pbs_node_file = teams_node_file['pbs']
+    else:
+        pbs_node_file = os.environ.get('PBS_NODE_FILE')
+
+    # Merge other schduler files here.
+
+    n_runs = len(object_list)
+
+    if pbs_node_file is not None:
+        pbs_nodes = []
+        # TODO: comment the target format here.
+        with open(pbs_node_file, 'r') as infile:
+            for line in infile:
+                pbs_nodes.append(line.rstrip())
+
+        n_total_processors = len(pbs_nodes) # less may be used.
+        n_teams = min(math.floor(len(pbs_nodes) / teams_exe_cmd_nproc), n_runs)
+        teams_dict = {}
+
+        # Map the objects on to the teams (this seems overly complicated, should prob
+        # consider using pandas:
+
+        # If the cast/ensemble is still in memory, this looks different.
+        if isinstance(object_list[0], wrfhydropy.Simulation):
+            object_dirs = [oo.run_dir for oo in object_list]
+        else:
+            object_dirs = object_list
+        
+        object_teams = [the_object % n_teams for the_object in range(n_runs)]
+        object_team_seq = [ [dir, team] for dir,team in zip(object_dirs, object_teams)]
+        object_team_seq.sort(key = operator.itemgetter(1))
+        team_groups = itertools.groupby(object_team_seq, operator.itemgetter(1))
+        team_objects = [[item[0] for item in data] for (key, data) in team_groups]
+
+        # Map the nodes on to the teams
+        # Homogonization step here to avoid communication across nodes...
+        # Sorting necessary for testing.
+        unique_nodes = sorted([node.split('.')[0] for node in list(set(pbs_nodes))])
+        print("Running on nodes: " + ', '.join(unique_nodes))
+        del pbs_nodes
+        pbs_nodes = []
+        for i_team in range(n_teams):
+            pbs_nodes = pbs_nodes + (
+                [unique_nodes[i_team % len(unique_nodes)]] * teams_exe_cmd_nproc)
+        node_teams = [the_node // teams_exe_cmd_nproc for the_node in range(len(pbs_nodes))]
+        node_team_seq = [ [node, team] for node,team in zip(pbs_nodes, node_teams)]
+        
+        node_team_seq.sort(key = operator.itemgetter(1))
+        team_groups = itertools.groupby(node_team_seq, operator.itemgetter(1))
+        team_nodes = [[item[0] for item in data] for (key, data) in team_groups]
+        
+        # Get the entry and exit commands from the job on the first cast/member
+        # Foolery for in/out of memory
+        if isinstance(object_list[0], str):
+            pkl_file = obj._compose_dir / (object_list[0] + '/WrfHydroSim.pkl')
+            jobs = pickle.load(pkl_file.open('rb')).jobs
+        else:
+            jobs = object_list[0].jobs
+        if len(jobs) > 1:
+            raise ValueError('Teams runs only support single job simulations')
+        entry_cmd = jobs[0]._entry_cmd
+        exit_cmd = jobs[0]._entry_cmd
+
+        # Assign teams!
+        for team in range(n_teams):
+            teams_dict.update({
+                team: {
+                    object_name: team_objects[team],
+                    'nodes': team_nodes[team],
+                    'entry_cmd': entry_cmd,
+                    'exit_cmd': exit_cmd,
+                    'exe_cmd': teams_exe_cmd,
+                    'env': env
+                }
+            })
+
+        print('\nPBS_NODE_FILE present: ')
+        print('    ' + str(len(unique_nodes)) + ' nodes with')
+        print('    ' + str(n_total_processors) + ' processors requested.')
+
+        print('\nTeams parallelization over:')
+        print('    ' + str(n_teams) + ' concurrent teams each using')
+        print('    ' + str(teams_exe_cmd_nproc) + ' processors.')    
+
+        return teams_dict

--- a/wrfhydropy/tests/conftest.py
+++ b/wrfhydropy/tests/conftest.py
@@ -246,13 +246,14 @@ def model_dir(tmpdir):
     with model_dir_path.joinpath('configure').open('w') as f:
         f.write('# dummy configure \n')
 
+    # Arugments passed to wrf_hydro.exe are echoed to diag_hydro.00000.
     dummy_compile = (
         "#!/bin/bash \n"
         "# dummy compile \n"
         "mkdir Run \n"
         "echo '#!/bin/bash \n"
-        "echo $@ \n"
-        "echo \'The model finished successfully.......\' >  diag_hydro.00000\n"
+        "echo $@ > diag_hydro.00000\n"
+        "echo \'The model finished successfully.......\' >>  diag_hydro.00000\n"
         "exit 0' > Run/wrf_hydro.exe\n"
         "touch Run/DUMMY.TBL \n"
     )

--- a/wrfhydropy/tests/data/nodefile_pbs_example_copy.txt
+++ b/wrfhydropy/tests/data/nodefile_pbs_example_copy.txt
@@ -1,0 +1,4 @@
+r10i1n1.ib0.cheyenne.ucar.edu
+r10i1n1.ib0.cheyenne.ucar.edu
+r10i1n2.ib0.cheyenne.ucar.edu
+r10i1n2.ib0.cheyenne.ucar.edu

--- a/wrfhydropy/tests/test_cycle.py
+++ b/wrfhydropy/tests/test_cycle.py
@@ -1066,7 +1066,7 @@ def test_cycle_ensemble_parallel_compose(
     assert time_taken < 1.5
 
 
-def test_cycle_run(
+def test_cycle_serial(
     simulation_compiled,
     job_restart,
     scheduler,
@@ -1075,14 +1075,11 @@ def test_cycle_run(
     init_times,
     restart_dirs
 ):
-
     sim = simulation_compiled
-
     tmp = pathlib.Path(tmpdir)
     forcing_dirs = [tmp / letter for letter in list(string.ascii_lowercase)[0:len(init_times)]]
     for dir in forcing_dirs:
         dir.mkdir()
-
     cy = CycleSimulation(
         init_times=init_times,
         restart_dirs=restart_dirs,
@@ -1090,7 +1087,6 @@ def test_cycle_run(
     )
     cy.add(sim)
     cy.add(job_restart)
-
     # Serial test
     cy_serial = copy.deepcopy(cy)
     cy_dir = pathlib.Path(tmpdir).joinpath('cycle_serial_run')
@@ -1103,6 +1099,28 @@ def test_cycle_run(
         "Some serial cycle casts did not run successfully."
     assert cy_dir.joinpath("WrfHydroCycle.pkl").exists()
 
+
+def test_cycle_run_parallel(
+    simulation_compiled,
+    job_restart,
+    scheduler,
+    tmpdir,
+    capfd,
+    init_times,
+    restart_dirs
+):
+    sim = simulation_compiled
+    tmp = pathlib.Path(tmpdir)
+    forcing_dirs = [tmp / letter for letter in list(string.ascii_lowercase)[0:len(init_times)]]
+    for dir in forcing_dirs:
+        dir.mkdir()
+    cy = CycleSimulation(
+        init_times=init_times,
+        restart_dirs=restart_dirs,
+        forcing_dirs=forcing_dirs
+    )
+    cy.add(sim)
+    cy.add(job_restart)
     # Parallel test
     cy_parallel = copy.deepcopy(cy)
     cy_dir = pathlib.Path(tmpdir).joinpath('cycle_parallel_run')
@@ -1115,6 +1133,28 @@ def test_cycle_run(
         "Some parallel cycle casts did not run successfully."
     assert cy_dir.joinpath("WrfHydroCycle.pkl").exists()
 
+
+def test_cycle_run_parallel_casts_in_memory(
+    simulation_compiled,
+    job_restart,
+    scheduler,
+    tmpdir,
+    capfd,
+    init_times,
+    restart_dirs
+):
+    sim = simulation_compiled
+    tmp = pathlib.Path(tmpdir)
+    forcing_dirs = [tmp / letter for letter in list(string.ascii_lowercase)[0:len(init_times)]]
+    for dir in forcing_dirs:
+        dir.mkdir()
+    cy = CycleSimulation(
+        init_times=init_times,
+        restart_dirs=restart_dirs,
+        forcing_dirs=forcing_dirs
+    )
+    cy.add(sim)
+    cy.add(job_restart)
     # Parallel test with ensemble in memory
     cy_parallel = copy.deepcopy(cy)
     cy_dir = pathlib.Path(tmpdir).joinpath('cy_parallel_run_cy_in_memory')
@@ -1127,6 +1167,28 @@ def test_cycle_run(
         "Some parallel cycle casts in memory did not run successfully."
     assert cy_dir.joinpath("WrfHydroCycle.pkl").exists()
 
+
+def test_cycle_run_parallel_teams(
+    simulation_compiled,
+    job_restart,
+    scheduler,
+    tmpdir,
+    capfd,
+    init_times,
+    restart_dirs
+):
+    sim = simulation_compiled
+    tmp = pathlib.Path(tmpdir)
+    forcing_dirs = [tmp / letter for letter in list(string.ascii_lowercase)[0:len(init_times)]]
+    for dir in forcing_dirs:
+        dir.mkdir()
+    cy = CycleSimulation(
+        init_times=init_times,
+        restart_dirs=restart_dirs,
+        forcing_dirs=forcing_dirs
+    )
+    cy.add(sim)
+    cy.add(job_restart)
     # Parallel teams test
     cy_teams = copy.deepcopy(cy)
     cy_dir = pathlib.Path(tmpdir).joinpath('cy_team')

--- a/wrfhydropy/tests/test_cycle.py
+++ b/wrfhydropy/tests/test_cycle.py
@@ -1219,7 +1219,6 @@ def test_cycle_run_parallel_teams(
         }
     }
     cy_teams_run_success = cy_teams.run(
-        n_concurrent=2,
         teams=True,
         teams_exe_cmd = ' ./wrf_hydro.exe mpirun --host {hostname} -np {nproc} {cmd}',
         teams_exe_cmd_nproc = 2,

--- a/wrfhydropy/tests/test_cycle.py
+++ b/wrfhydropy/tests/test_cycle.py
@@ -1127,6 +1127,35 @@ def test_cycle_run(
         "Some parallel cycle casts in memory did not run successfully."
     assert cy_dir.joinpath("WrfHydroCycle.pkl").exists()
 
+    # Parallel teams test
+    cy_teams = copy.deepcopy(cy)
+    cy_dir = pathlib.Path(tmpdir).joinpath('cy_team')
+    os.chdir(tmpdir)
+    os.mkdir(str(cy_dir))
+    os.chdir(str(cy_dir))
+    cy_teams.compose()
+    # cy_teams.compose(rm_casts_from_memory=False)
+    teams_dict = {
+        '0': {
+            'casts': ['cast_2012121200', 'cast_2012121800'],
+            'nodes': ['hostname0'],
+            'entry_cmd': 'echo',
+            'exe_cmd': './wrf_hydro.exe {hostname} {nproc}',
+            'exit_cmd': './bogus_cmd'
+        },
+        '1': {
+            'casts': ['cast_2012121500'],
+            'nodes': ['hostname1'],
+            'entry_cmd': 'pwd',
+            'exe_cmd': './wrf_hydro.exe {hostname} {nproc}',
+            'exit_cmd': './bogus_cmd'
+        }
+    }
+    cy_teams_run_success = cy_teams.run(teams_dict=teams_dict)
+    assert cy_teams_run_success == 0, \
+        "Some parallel team cycle casts did not run successfully."
+    assert cy_dir.joinpath("WrfHydroCycle.pkl").exists()
+
 
 def test_cycle_self_dependent_run(
     simulation_compiled,

--- a/wrfhydropy/tests/test_ensemble.py
+++ b/wrfhydropy/tests/test_ensemble.py
@@ -383,21 +383,19 @@ def test_ens_teams_run(simulation_compiled, job, scheduler, tmpdir, capfd):
         '0': {
             'members': ['member_000', 'member_002'],
             'nodes': ['hostname0'],
-            'entry_cmd': 'echo',
-            'exe_cmd': './wrf_hydro.exe {hostname} {nproc}',
-            'exit_cmd': './bogus_cmd'
+            'exe_cmd': './wrf_hydro.exe mpirun --host {hostname} -np {nproc} {cmd}',
         },
         '1': {
             'members': ['member_001', 'member_003'],
             'nodes': ['hostname1', 'hostname1'],
-            'entry_cmd': 'pwd',
-            'exe_cmd': './wrf_hydro.exe {hostname} {nproc}',
-            'exit_cmd': './bogus_cmd'
+            'exe_cmd': './wrf_hydro.exe mpirun --host {hostname} -np {nproc} {cmd}',
         }
     }
 
     sim = simulation_compiled
     ens = EnsembleSimulation()
+    job._entry_cmd = 'echo mpirun entry_cmd > entry_cmd.output'
+    job._exit_cmd = 'echo mpirun exit_cmd > exit_cmd.output'
     ens.add(job)
     ens.add([sim, sim, sim, sim])
 
@@ -410,10 +408,28 @@ def test_ens_teams_run(simulation_compiled, job, scheduler, tmpdir, capfd):
     assert ens_run_success == 0, \
         "Some teams ensemble members did not run successfully."
 
-    answers = ['hostname0 1\n', 'hostname1,hostname1 2\n',
-               'hostname0 1\n', 'hostname1,hostname1 2\n']
-    for answer, std_out_file in zip(
-            answers,
-            sorted(ens_dir.glob('member_00*/job*/test_job*stdout'))
-    ):
-        assert answer == std_out_file.open('r').readline()
+    def check_first_line(file, answer):
+        with open(file) as f:
+            first_line = f.readline()
+        assert first_line == answer
+
+    # Check for command correctness in output files.
+    file_check = {
+        ('member_000/entry_cmd.output',
+         'member_001/entry_cmd.output',
+         'member_002/entry_cmd.output',
+         'member_003/entry_cmd.output'): 'mpirun entry_cmd\n',
+        ('member_000/exit_cmd.output',
+         'member_001/exit_cmd.output',
+         'member_002/exit_cmd.output',
+         'member_003/exit_cmd.output'): 'mpirun exit_cmd\n',
+        ('member_000/job_test_job_1/diag_hydro.00000',
+         'member_002/job_test_job_1/diag_hydro.00000'):
+            'mpirun --host hostname0 -np 1 ./wrf_hydro.exe\n',
+        ('member_001/job_test_job_1/diag_hydro.00000',
+         'member_003/job_test_job_1/diag_hydro.00000'):
+            'mpirun --host hostname1,hostname1 -np 2 ./wrf_hydro.exe\n'
+    }
+    for tup, ans in file_check.items():
+        for file in tup:
+            check_first_line(file, ans)


### PR DESCRIPTION
This is tested. Passes the collection tests on my osx but not on cheyenne. The outputdiffs tests fail on osx but pass on cheyenne. I still dont understand where the type differences are coming from. I'm going to have to get to the bottom of this soon... already scratched my head a bunch.

Adds functionality for using multiprocess as it an internal scheduler and kicking PBS to the curb after getting the desired resources. 

Abstracted the teams used by the ensemble into their own module. 

Found a drawback is that when the number of teams is large, the master node load average is perty high. There are probably ways to deal with this but for now it works well enough!
