### PR TITLE
Add optional job-name prefix to scheduled jobs

### DIFF
--- a/wrfhydropy/core/schedulers.py
+++ b/wrfhydropy/core/schedulers.py
@@ -113,9 +113,13 @@ class PBSCheyenne(Scheduler):
         """Private method to write bash PBS scripts for submitting each job """
         import copy
         import sys
+        import os
 
         # Get the current pytohn executable to handle virtual environments in the scheduler
         python_path = sys.executable
+
+        # Check for a job prefix
+        job_prefix = os.environ.get('WRF_HYDRO_JOB_PREFIX', '')
 
         for job in jobs:
             # Copy the job because the exe cmd is edited below
@@ -124,7 +128,7 @@ class PBSCheyenne(Scheduler):
             # Write PBS script
             jobstr = ""
             jobstr += "#!/bin/sh\n"
-            jobstr += "#PBS -N {0}\n".format(job.job_id)
+            jobstr += "#PBS -N {0}{1}\n".format(job_prefix, job.job_id)
             jobstr += "#PBS -A {0}\n".format(self.scheduler_opts['account'])
             jobstr += "#PBS -q {0}\n".format(self.scheduler_opts['queue'])
 


### PR DESCRIPTION
Adds a provision for a prefix to be prepended to scheduled jobs based on a (completely optional) environment variable, `WRF_HYDRO_JOB_PREFIX`). When test jobs spawn sub-jobs, particularly in the parallel case, this makes it far easier to keep track of what goes with what.

This code is completely backwards-compatible; if the env var is not specified, behavior is unchanged.