### PR TITLE
hotfix: pathlib package and Numpy version errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,8 @@ dask[bag]>=2.14.0
 deepdiff==3.3.0
 f90nml>=1.2
 netCDF4>=1.5.3
-numpy==1.22.0
+numpy==1.21.0
 pandas>=1.0.3
-pathlib==1.0.1
 properscoring==0.1
 pytest>=5.4.1
 pytest-html>=3.0.0


### PR DESCRIPTION
- Python package pathlib was giving no abbtribute 'read_text' errors during `import wrfhydropy`. Removed it from requirements.txt
- the numpy version was too high for Python 3.7. Lowering the numpy version fixed that issue